### PR TITLE
escaped "|" character inside the table

### DIFF
--- a/2014/liferay-integration-points/liferay-integration-points.adoc
+++ b/2014/liferay-integration-points/liferay-integration-points.adoc
@@ -155,7 +155,7 @@ Liferay Portal's core contains the following integration points described by the
 
 |`com.liferay.portal.kernel.struts.StrutsAction` +
 `com.liferay.portal.kernel.struts.StrutsPortletAction`
-|`(&(|(objectClass=com.liferay.portal.kernel.struts.StrutsAction)(objectClass=com.liferay.portal.kernel.struts.StrutsPortletAction))(path=*))`
+|`(&(\|(objectClass=com.liferay.portal.kernel.struts.StrutsAction)(objectClass=com.liferay.portal.kernel.struts.StrutsPortletAction))(path=*))`
 
 |`com.liferay.portal.model.LayoutTypeController`
 |`(&(layout.type=*)(objectClass=com.liferay.portal.model.LayoutTypeController))`


### PR DESCRIPTION
It was treated as column delimiter causing following rows to look weird
